### PR TITLE
LTI timestamp error fixed

### DIFF
--- a/docroot/WEB-INF/liferay-plugin-package.properties
+++ b/docroot/WEB-INF/liferay-plugin-package.properties
@@ -1,6 +1,6 @@
 name=LTI
 module-group-id=liferay
-module-incremental-version=4.4
+module-incremental-version=4.5
 tags=
 short-description=
 change-log=

--- a/docroot/WEB-INF/src/net/oauth/OAuthMessage.java
+++ b/docroot/WEB-INF/src/net/oauth/OAuthMessage.java
@@ -277,7 +277,8 @@ public class OAuthMessage {
         }
         if (pMap.get(OAuth.OAUTH_TIMESTAMP) == null) {
         	//TODO TLS modification the timestamp is very exact
-            addParameter(OAuth.OAUTH_TIMESTAMP, (System.currentTimeMillis()+10000 / 1000) + "");
+        	// issued fixed with mcgrawhill provided, somehow it´s  sending milliseconds instead of seconds as oauth requires 
+            addParameter(OAuth.OAUTH_TIMESTAMP, (System.currentTimeMillis() /  1000) + "");
         }
         if (pMap.get(OAuth.OAUTH_NONCE) == null) {
             addParameter(OAuth.OAUTH_NONCE, System.nanoTime() + "");

--- a/docroot/WEB-INF/src/net/oauth/OAuthMessage.java
+++ b/docroot/WEB-INF/src/net/oauth/OAuthMessage.java
@@ -277,7 +277,7 @@ public class OAuthMessage {
         }
         if (pMap.get(OAuth.OAUTH_TIMESTAMP) == null) {
         	//TODO TLS modification the timestamp is very exact
-        	// issued fixed with mcgrawhill provided, somehow it´s  sending milliseconds instead of seconds as oauth requires 
+        	// issued fixed with mcgrawhill provided, somehow it´s  sending milliseconds instead of seconds as oauth requires as specification
             addParameter(OAuth.OAUTH_TIMESTAMP, (System.currentTimeMillis() /  1000) + "");
         }
         if (pMap.get(OAuth.OAUTH_NONCE) == null) {


### PR DESCRIPTION
Timestamp is set to seconds instead of millisecods, which causes LTI negotiation failure. Tested at ITT WebSite with Mcgrawth Hill  provider